### PR TITLE
Fixes bad predicate and file permissions

### DIFF
--- a/root/usr/share/clearwater-infrastructure/scripts/restart/chronos_restart
+++ b/root/usr/share/clearwater-infrastructure/scripts/restart/chronos_restart
@@ -16,6 +16,7 @@ CHRONOS_CONF=/etc/chronos/chronos_shared.conf
 
 # Generate the related Chronos configuration
 TMPFILE=$(mktemp)
+chmod +r $TMPFILE
 echo "[dns]" >> $TMPFILE
 for server in $signaling_dns_server
 do
@@ -31,7 +32,7 @@ do
 done
 
 # If the config has changed, upload it to etcd
-if [[ ! -f $CHRONOS_CONF || ! cmp $TMPFILE $CHRONOS_CONF ]]
+if [[ ! -f $CHRONOS_CONF ]] || ! cmp $TMPFILE $CHRONOS_CONF
 then
   mv $TMPFILE $CHRONOS_CONF
   /usr/share/clearwater/clearwater-config-manager/scripts/upload_chronos_shared_config


### PR DESCRIPTION
There was a bad predicate, that I'd failed to copy from my test box back to my dev box 😞.

Also, the config file has to be readable to the chronos user, so I've set the permissions to match the other chronos config files (644).